### PR TITLE
Refactor several small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,28 @@
 ![](http://img.shields.io/npm/dm/remark-title.svg?style=flat)
 ![](http://img.shields.io/npm/l/remark-title.svg?style=flat)
 
-[mdast](https://github.com/wooorm/mdast) plugin to check and inject the title
+[remark](https://github.com/wooorm/remark) plugin to check and inject the title
 of a markdown as the first element.
 
 ## Usage
 
 [![NPM](https://nodei.co/npm/remark-title.png)](https://nodei.co/npm/remark-title/)
 
-Used as a plugin for mdast like so:
+Used as a plugin for remark like so:
 
 ```javascript
-const plugin = require('remark-title')
-const mdast  = require('mdast')
+const title = require('remark-title')
+const remark  = require('remark')
 
-readme = mdast.use(plugin).process(readme)
+readme = remark.use(title, {
+  'title': 'remark-title'
+}).process(readme)
 ```
 
 This will add a title to your document if one is not already present.
-The title will be the name of the folder, unless specified as an option.
-If an existing title is different, it will replace it.
+The title will be the name of the folder ([`VFile#directory`](https://github.com/wooorm/vfile#vfiledirectory),
+when available, or `__dirname`), unless specified as an option.
+If an existing title is different (case-insensitive), it will replace it.
 
 For example, the following input markdown:
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
+var sep = require('path').sep
 var last = require('lodash').last
-var mdast = require('mdast')
+var toString = require('mdast-util-to-string')
 
 module.exports = checkTitle
 
-function checkTitle (mdast, opts) {
+function checkTitle (remark, opts) {
   return function checkTitleTransformer (root, file) {
     var children = root.children
-    var headingText = (opts && opts.title) ? opts.title : last(__dirname.split('/'))
+    var fileDir = last(file.directory.split(sep));
+    var baseDir = last(__dirname.split(sep));
+    var headingText = (opts && opts.title) ? opts.title : fileDir || baseDir
+    var node = children[0]
     var title = {
       type: 'heading',
       depth: 1,
@@ -17,11 +21,9 @@ function checkTitle (mdast, opts) {
 
     // Replace heading if it is incorrect
     // Do nothing if it is fine
-    if (children[0].type === 'heading') {
-      var text = mdast.stringify({
-        children: children[0].children,
-        type: 'root'
-      }).toLowerCase()
+    if (node && node.type === 'heading') {
+      var text = toString(node)
+        .toLowerCase()
         .replace(/\s+/g, ' ')
         .trim()
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "mdast": "^2.1.0"
+    "mdast-util-to-string": "^1.0.0"
   },
   "devDependencies": {
     "diff": "^1.4.0",
@@ -22,7 +22,8 @@
     "tape": "^4.0.0",
     "fs": "0.0.2",
     "graceful-fs": "^4.1.2",
-    "mdast-lint": "^1.1.1"
+    "remark": "^3.0.0",
+    "remark-lint": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "mdast": "^2.1.0",
+    "mdast": "^2.1.0"
   },
   "devDependencies": {
     "diff": "^1.4.0",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const mdast = require('mdast')
+const remark = require('remark')
 const test = require('tape')
 const diff = require('diff')
 const plugin = require('./')
@@ -18,7 +18,7 @@ const expected = {
 
 test('remark-title', function (t) {
   Object.keys(fixtures).forEach(function (name) {
-    var processor = mdast.use(plugin)
+    var processor = remark.use(plugin)
 
     const actual = processor.process(fs.readFileSync(fixtures[name], 'utf8')).trim()
     const expect = fs.readFileSync(expected[name], 'utf8').trim()
@@ -34,7 +34,7 @@ test('remark-title', function (t) {
 })
 
 test('remark-title with option', function (t) {
-  var processor = mdast.use(plugin, {
+  var processor = remark.use(plugin, {
     title: 'remark-replace'
   })
 


### PR DESCRIPTION
- Update mdast to remark;
- Fix to support empty files;
- Add support for windows by using `path.sep` instead of `/`;
- Prefer `file.directory` above `__dirname`, as `file.directory`,
  when available, refers to the directory of the processed file
  on the CLI.
- Remove dependency of `mdast` (or `remark`), preferring
  `mdast-util-to-string` over loading the complete library.
- Mention case-insensitive matching in `README.md`;
- Mention fallbacks of `title` `README.md`;
- Show `options.title` usage in `README.md`.

(ping me if I should explain some stuff better)

Includes the commit of GH-1 because I couldn’t work without it :smile: 
